### PR TITLE
Implement CSS Style Resolver

### DIFF
--- a/internal/renderer/node.go
+++ b/internal/renderer/node.go
@@ -30,6 +30,7 @@ type RenderNode struct {
 	TagName       string            // HTML tag name (e.g., "div", "p", "h1")
 	Text          string            // Text content for text nodes
 	Attrs         map[string]string // HTML attributes
+	Styles        map[string]string // CSS styles
 	Children      []*RenderNode     // Child nodes
 	Parent        *RenderNode       // Parent node
 	ComputedStyle *Style
@@ -139,6 +140,7 @@ func NewRenderNode(nodeType NodeType) *RenderNode {
 		ID:            atomic.AddInt64(&nodeIDCounter, 1),
 		Type:          nodeType,
 		Attrs:         make(map[string]string),
+		Styles:        make(map[string]string),
 		Children:      make([]*RenderNode, 0),
 		Box:           &Box{},
 		ComputedStyle: &Style{},

--- a/internal/renderer/style.go
+++ b/internal/renderer/style.go
@@ -441,6 +441,11 @@ var colorNameToHex = map[string]string{
 }
 
 func (sm *StyleManager) applyDeclaration(node *RenderNode, decl css.Declaration) {
+	if node.Styles == nil {
+		node.Styles = make(map[string]string)
+	}
+	node.Styles[decl.Property] = decl.Value
+
 	style := node.ComputedStyle
 	switch decl.Property {
 	case "display":

--- a/internal/renderer/style_resolver.go
+++ b/internal/renderer/style_resolver.go
@@ -1,0 +1,43 @@
+package renderer
+
+import (
+	"github.com/vyquocvu/goosie/internal/css"
+)
+
+// StyleResolver walks the DOM and matches parsed CSS rules to RenderNode objects.
+type StyleResolver struct {
+	stylesheet *css.StyleSheet
+}
+
+// NewStyleResolver creates a new StyleResolver with the given stylesheet.
+func NewStyleResolver(stylesheet *css.StyleSheet) *StyleResolver {
+	return &StyleResolver{
+		stylesheet: stylesheet,
+	}
+}
+
+// Resolve walks the DOM tree and matches CSS rules to each node,
+// storing the computed values in the node's Styles map.
+func (sr *StyleResolver) Resolve(node *RenderNode) {
+	sm := NewStyleManager(sr.stylesheet)
+	sr.resolveRecursive(node, sm)
+}
+
+func (sr *StyleResolver) resolveRecursive(node *RenderNode, sm *StyleManager) {
+	if node == nil {
+		return
+	}
+
+	if node.Styles == nil {
+		node.Styles = make(map[string]string)
+	}
+
+	if sr.stylesheet != nil {
+		sm.applyMatchingRules(sr.stylesheet, node)
+	}
+
+	// Recursively resolve for children
+	for _, child := range node.Children {
+		sr.resolveRecursive(child, sm)
+	}
+}

--- a/internal/renderer/style_resolver_test.go
+++ b/internal/renderer/style_resolver_test.go
@@ -1,0 +1,22 @@
+package renderer
+
+import (
+	"testing"
+
+	"github.com/vyquocvu/goosie/internal/css"
+)
+
+func TestStyleResolver(t *testing.T) {
+	parser := css.NewParser("div { color: red; }")
+	stylesheet, _ := parser.Parse()
+	resolver := NewStyleResolver(stylesheet)
+
+	node := NewRenderNode(NodeTypeElement)
+	node.TagName = "div"
+
+	resolver.Resolve(node)
+
+	if node.Styles["color"] != "red" {
+		t.Errorf("expected color red, got %s", node.Styles["color"])
+	}
+}


### PR DESCRIPTION
This change implements the requested CSS style resolution feature.

1.  A new `Styles` map (`map[string]string`) was added to `RenderNode` (`internal/renderer/node.go`) and properly initialized.
2.  `StyleManager` (`internal/renderer/style.go`) was updated to populate this `Styles` map whenever a CSS declaration is matched.
3.  A dedicated `StyleResolver` type was created (`internal/renderer/style_resolver.go`) that explicitly walks the DOM tree and matches CSS rules using the `StyleManager`, directly satisfying the "Style Resolver" requirement.
4.  Test coverage was added to verify the `StyleResolver` works as intended.

---
*PR created automatically by Jules for task [14649390121341451225](https://jules.google.com/task/14649390121341451225) started by @vyquocvu*