### PR TITLE
[M0.4] Add benchmark and profiling commands

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -279,3 +279,50 @@ go tool pprof mem.prof
 ---
 
 *Last updated: July 2026*
+
+## Running Benchmarks and Profiling
+
+The repository includes a script to simplify running benchmarks, capturing profiles, and comparing results.
+
+### Using `scripts/bench.sh`
+
+The `bench.sh` script provides the following commands:
+
+*   **`run [package]`**: Runs all `testing.B` benchmarks in the specified package (or `./...` by default) with `-benchmem` enabled to report allocations.
+    ```bash
+    ./scripts/bench.sh run ./internal/renderer
+    ```
+
+*   **`suite`**: Runs the full local performance suite across the entire repository and saves the output to `perf-suite.txt`.
+    ```bash
+    ./scripts/bench.sh suite
+    ```
+
+*   **`profile-cpu <package> [regex]`**: Runs benchmarks matching the regex and captures a CPU profile to `cpu.prof`.
+    ```bash
+    ./scripts/bench.sh profile-cpu ./internal/renderer ViewportScroll
+    # To view: go tool pprof cpu.prof
+    ```
+
+*   **`profile-mem <package> [regex]`**: Runs benchmarks matching the regex and captures a memory profile to `mem.prof`.
+    ```bash
+    ./scripts/bench.sh profile-mem ./internal/renderer ViewportScroll
+    # To view: go tool pprof mem.prof
+    ```
+
+*   **`trace <package> [regex]`**: Captures a runtime execution trace for scenario benchmarks to `trace.out`.
+    ```bash
+    ./scripts/bench.sh trace ./internal/engine/testpages BenchmarkGetLongArticle
+    # To view: go tool trace trace.out
+    ```
+
+*   **`compare <old.txt> <new.txt>`**: Compares two benchmark result files using `benchstat`. This is essential for verifying performance improvements or regressions before merging. (Automatically installs `benchstat` if missing).
+    ```bash
+    # On main branch
+    ./scripts/bench.sh suite
+    mv perf-suite.txt main-perf.txt
+
+    # On feature branch
+    ./scripts/bench.sh suite
+    ./scripts/bench.sh compare main-perf.txt perf-suite.txt
+    ```

--- a/README.md
+++ b/README.md
@@ -308,3 +308,25 @@ See [ROADMAP_V2.md](ROADMAP_V2.md) for planned features and future development g
 ## License
 
 This project is provided as-is for educational purposes.
+
+### Profiling and Tracing
+We provide a convenient bash script at `scripts/bench.sh` to quickly run performance tools:
+```bash
+# Run all benchmarks across the project
+./scripts/bench.sh run
+
+# Capture CPU profile
+./scripts/bench.sh profile-cpu ./internal/renderer
+
+# Capture Memory profile
+./scripts/bench.sh profile-mem ./internal/renderer
+
+# Capture runtime trace
+./scripts/bench.sh trace ./internal/engine/testpages
+
+# Run the full benchmark suite
+./scripts/bench.sh suite
+
+# Compare benchmark results with benchstat
+./scripts/bench.sh compare main-perf.txt feature-perf.txt
+```

--- a/ROADMAP_V2.md
+++ b/ROADMAP_V2.md
@@ -226,12 +226,12 @@ Establish a trustworthy baseline before changing core data structures. Lock the 
 
 ### M0.4 Add benchmark and profiling commands
 
-- [ ] Add package-level `testing.B` benchmarks.
-- [ ] Add `-benchmem` documentation.
-- [ ] Add optional CPU and heap profile output.
-- [ ] Add runtime trace capture for scenario benchmarks.
-- [ ] Add a command that runs the full local performance suite.
-- [ ] Add a benchmark comparison script using `benchstat`.
+- [x] Add package-level `testing.B` benchmarks.
+- [x] Add `-benchmem` documentation.
+- [x] Add optional CPU and heap profile output.
+- [x] Add runtime trace capture for scenario benchmarks.
+- [x] Add a command that runs the full local performance suite.
+- [x] Add a benchmark comparison script using `benchstat`.
 
 **Acceptance criteria**
 

--- a/internal/js/benchmark_test.go
+++ b/internal/js/benchmark_test.go
@@ -1,0 +1,41 @@
+package js
+
+import (
+	"testing"
+)
+
+func BenchmarkRuntimeCreate(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		rt := NewRuntime()
+		rt.Cleanup()
+	}
+}
+
+func BenchmarkRuntimeRunScriptSimple(b *testing.B) {
+	rt := NewRuntime()
+	defer rt.Cleanup()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := rt.RunScript("1 + 1")
+		if err != nil {
+			b.Fatalf("RunScript failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkRuntimeRunScriptDOM(b *testing.B) {
+	rt := NewRuntime()
+	defer rt.Cleanup()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := rt.RunScript("document.createElement('div');")
+		if err != nil {
+			b.Fatalf("RunScript failed: %v", err)
+		}
+	}
+}

--- a/internal/net/benchmark_test.go
+++ b/internal/net/benchmark_test.go
@@ -1,0 +1,63 @@
+package net
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func BenchmarkFetchSimple(b *testing.B) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Hello, benchmark!"))
+	}))
+	defer ts.Close()
+
+	svc := NewService(ServiceOptions{})
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := svc.FetchWithContext(ctx, ts.URL, nil)
+		if err != nil {
+			b.Fatalf("Fetch failed: %v", err)
+		}
+	}
+}
+
+func BenchmarkFetchCached(b *testing.B) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Cached response"))
+	}))
+	defer ts.Close()
+
+	tempDir, err := os.MkdirTemp("", "goosie_net_bench_")
+	if err != nil {
+		b.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	cache := NewHTTPCache(tempDir, false)
+	svc := NewService(ServiceOptions{Cache: cache})
+	ctx := context.Background()
+
+	// Initial fetch to populate cache
+	_, err = svc.FetchWithContext(ctx, ts.URL, nil)
+	if err != nil {
+		b.Fatalf("Initial fetch failed: %v", err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := svc.FetchWithContext(ctx, ts.URL, nil)
+		if err != nil {
+			b.Fatalf("Cached fetch failed: %v", err)
+		}
+	}
+}

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -e
+
+COMMAND=$1
+shift || true
+
+if [ "$COMMAND" = "run" ]; then
+    PKG=${1:-./...}
+    echo "Running benchmarks for $PKG..."
+    go test -run=^$ -bench=. -benchmem "$PKG"
+elif [ "$COMMAND" = "profile-cpu" ]; then
+    PKG=$1
+    if [ -z "$PKG" ]; then
+      echo "Usage: $0 profile-cpu <package> [benchmark-regex]"
+    else
+      BENCH=${2:-.}
+      echo "Capturing CPU profile for $PKG (bench: $BENCH)..."
+      go test -run=^$ -bench="$BENCH" -cpuprofile=cpu.prof "$PKG"
+      echo "Profile saved to cpu.prof. To view: go tool pprof cpu.prof"
+    fi
+elif [ "$COMMAND" = "profile-mem" ]; then
+    PKG=$1
+    if [ -z "$PKG" ]; then
+      echo "Usage: $0 profile-mem <package> [benchmark-regex]"
+    else
+      BENCH=${2:-.}
+      echo "Capturing memory profile for $PKG (bench: $BENCH)..."
+      go test -run=^$ -bench="$BENCH" -memprofile=mem.prof "$PKG"
+      echo "Profile saved to mem.prof. To view: go tool pprof mem.prof"
+    fi
+elif [ "$COMMAND" = "trace" ]; then
+    PKG=$1
+    if [ -z "$PKG" ]; then
+      echo "Usage: $0 trace <package> [benchmark-regex]"
+    else
+      BENCH=${2:-.}
+      echo "Capturing runtime trace for $PKG (bench: $BENCH)..."
+      go test -run=^$ -bench="$BENCH" -trace=trace.out "$PKG"
+      echo "Trace saved to trace.out. To view: go tool trace trace.out"
+    fi
+elif [ "$COMMAND" = "compare" ]; then
+    OLD_FILE=$1
+    NEW_FILE=$2
+    if [ -z "$OLD_FILE" ] || [ -z "$NEW_FILE" ]; then
+      echo "Usage: $0 compare <old-results.txt> <new-results.txt>"
+      echo "Note: requires benchstat (go install golang.org/x/perf/cmd/benchstat@latest)"
+    else
+      if ! command -v benchstat &> /dev/null; then
+          echo "benchstat not found, installing..."
+          go install golang.org/x/perf/cmd/benchstat@latest
+      fi
+      benchstat "$OLD_FILE" "$NEW_FILE"
+    fi
+elif [ "$COMMAND" = "suite" ]; then
+    echo "Running full performance suite..."
+    go test -run=^$ -bench=. -benchmem ./... > perf-suite.txt
+    echo "Results saved to perf-suite.txt"
+else
+    echo "Usage: $0 <command> [args...]"
+    echo "Commands:"
+    echo "  run [package]                       Run benchmarks (default: ./...)"
+    echo "  suite                               Run full performance suite and save to perf-suite.txt"
+    echo "  profile-cpu <package> [regex]       Capture CPU profile"
+    echo "  profile-mem <package> [regex]       Capture memory profile"
+    echo "  trace <package> [regex]             Capture runtime trace"
+    echo "  compare <old.txt> <new.txt>         Compare results using benchstat"
+fi


### PR DESCRIPTION
Adds benchmarking and profiling tools for M0.4. Provides bash wrapper for testing.B benchmarks and updates documentation.

---
*PR created automatically by Jules for task [10419394272268970690](https://jules.google.com/task/10419394272268970690) started by @vyquocvu*