### PR TITLE
Implement bounded LRU cache for TextShaper

### DIFF
--- a/ROADMAP_V2.md
+++ b/ROADMAP_V2.md
@@ -711,7 +711,7 @@ Make memory and storage behavior predictable across repeated navigation and mult
 - [ ] Page cache.
 - [ ] Decoded image cache.
 - [ ] Glyph cache.
-- [ ] Text shaping cache.
+- [x] Text shaping cache.
 - [ ] Selector and computed-style caches.
 - [ ] Layout intrinsic-size cache.
 - [ ] Tile cache.

--- a/internal/engine/session/session_test.go
+++ b/internal/engine/session/session_test.go
@@ -730,8 +730,11 @@ func TestSessionStateAfterCloseDoesNotFireTransitions(t *testing.T) {
 	s.Close()
 
 	var called bool
+	var mu sync.Mutex
 	s.SetEventCallback(func(ev Event) {
+		mu.Lock()
 		called = true
+		mu.Unlock()
 	})
 
 	s.Parsing()
@@ -739,6 +742,8 @@ func TestSessionStateAfterCloseDoesNotFireTransitions(t *testing.T) {
 	s.Complete()
 	s.FlushEvents()
 
+	mu.Lock()
+	defer mu.Unlock()
 	if called {
 		t.Fatal("event callback was called after Close")
 	}

--- a/internal/renderer/text_shaping.go
+++ b/internal/renderer/text_shaping.go
@@ -83,16 +83,39 @@ type ShapedText struct {
 	Descent float32
 }
 
-// TextShaper shapes and measures text with caching.
-type TextShaper struct {
-	mu    sync.RWMutex
-	cache map[string]*ShapedText // Cache key -> shaped text
+// cacheEntry represents an entry in the TextShaper LRU cache.
+type cacheEntry struct {
+	key   string
+	value *ShapedText
+	prev  *cacheEntry
+	next  *cacheEntry
 }
 
-// NewTextShaper creates a new text shaper.
+// TextShaper shapes and measures text with caching.
+type TextShaper struct {
+	mu        sync.Mutex
+	capacity  int
+	cache     map[string]*cacheEntry // Cache key -> LRU node
+	head      *cacheEntry            // most recently used
+	tail      *cacheEntry            // least recently used
+	Hits      int64
+	Misses    int64
+	Evictions int64
+}
+
+// NewTextShaper creates a new text shaper with a default cache capacity of 1024.
 func NewTextShaper() *TextShaper {
+	return NewTextShaperWithCapacity(1024)
+}
+
+// NewTextShaperWithCapacity creates a new text shaper with the specified cache capacity.
+func NewTextShaperWithCapacity(capacity int) *TextShaper {
+	if capacity <= 0 {
+		capacity = 1024
+	}
 	return &TextShaper{
-		cache: make(map[string]*ShapedText),
+		capacity: capacity,
+		cache:    make(map[string]*cacheEntry, capacity),
 	}
 }
 
@@ -109,24 +132,88 @@ func (s *TextShaper) Shape(text string, font FontKey) *ShapedText {
 		}
 	}
 
-	// Check cache
 	cacheKey := text + "|" + font.CacheKey()
-	s.mu.RLock()
-	cached, ok := s.cache[cacheKey]
-	s.mu.RUnlock()
-	if ok {
-		return cached
-	}
 
-	// Shape the text
+	// Check cache
+	s.mu.Lock()
+	e, ok := s.cache[cacheKey]
+	if ok {
+		s.moveToFront(e)
+		s.Hits++
+		result := e.value
+		s.mu.Unlock()
+		return result
+	}
+	s.Misses++
+	s.mu.Unlock()
+
+	// Shape the text outside the lock
 	result := s.shapeText(text, font)
 
 	// Cache the result
 	s.mu.Lock()
-	s.cache[cacheKey] = result
-	s.mu.Unlock()
+	defer s.mu.Unlock()
+
+	// Check again in case another goroutine shaped it
+	if e, ok := s.cache[cacheKey]; ok {
+		s.moveToFront(e)
+		return e.value
+	}
+
+	// Evict if at capacity
+	if len(s.cache) >= s.capacity {
+		s.evictLRU()
+	}
+
+	e = &cacheEntry{key: cacheKey, value: result}
+	s.cache[cacheKey] = e
+	s.pushFront(e)
 
 	return result
+}
+
+func (s *TextShaper) evictLRU() {
+	if s.tail == nil {
+		return
+	}
+	delete(s.cache, s.tail.key)
+	s.removeEntry(s.tail)
+	s.Evictions++
+}
+
+func (s *TextShaper) moveToFront(e *cacheEntry) {
+	if s.head == e {
+		return
+	}
+	s.removeEntry(e)
+	s.pushFront(e)
+}
+
+func (s *TextShaper) pushFront(e *cacheEntry) {
+	e.prev = nil
+	e.next = s.head
+	if s.head != nil {
+		s.head.prev = e
+	}
+	s.head = e
+	if s.tail == nil {
+		s.tail = e
+	}
+}
+
+func (s *TextShaper) removeEntry(e *cacheEntry) {
+	if e.prev != nil {
+		e.prev.next = e.next
+	} else {
+		s.head = e.next
+	}
+	if e.next != nil {
+		e.next.prev = e.prev
+	} else {
+		s.tail = e.prev
+	}
+	e.prev = nil
+	e.next = nil
 }
 
 // shapeText performs the actual text shaping.
@@ -247,12 +334,17 @@ func (s *TextShaper) MeasureWrappedNoWrap(text string, font FontKey, maxWidth fl
 func (s *TextShaper) ClearCache() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.cache = make(map[string]*ShapedText)
+	s.cache = make(map[string]*cacheEntry, s.capacity)
+	s.head = nil
+	s.tail = nil
+	s.Hits = 0
+	s.Misses = 0
+	s.Evictions = 0
 }
 
 // CacheSize returns the number of cached shaped texts.
 func (s *TextShaper) CacheSize() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return len(s.cache)
 }

--- a/internal/renderer/text_shaping_test.go
+++ b/internal/renderer/text_shaping_test.go
@@ -55,6 +55,58 @@ func TestShapeTextCaching(t *testing.T) {
 	if result1 != result2 {
 		t.Error("expected cached result to be returned")
 	}
+
+	if shaper.Hits != 1 {
+		t.Errorf("expected 1 hit, got %d", shaper.Hits)
+	}
+	if shaper.Misses != 1 {
+		t.Errorf("expected 1 miss, got %d", shaper.Misses)
+	}
+}
+
+func TestTextShaper_Eviction(t *testing.T) {
+	shaper := NewTextShaperWithCapacity(2)
+	key := FontKey{Size: 16}
+
+	// Add two items, filling the cache
+	shaper.Shape("A", key)
+	shaper.Shape("B", key)
+	if shaper.CacheSize() != 2 {
+		t.Errorf("expected cache size 2, got %d", shaper.CacheSize())
+	}
+
+	// Add a third item, which should evict "A"
+	shaper.Shape("C", key)
+	if shaper.CacheSize() != 2 {
+		t.Errorf("expected cache size 2 after eviction, got %d", shaper.CacheSize())
+	}
+	if shaper.Evictions != 1 {
+		t.Errorf("expected 1 eviction, got %d", shaper.Evictions)
+	}
+
+	// Requesting "B" should be a hit
+	shaper.Shape("B", key)
+	if shaper.Hits != 1 {
+		t.Errorf("expected 1 hit for B, got %d", shaper.Hits)
+	}
+
+	// Requesting "A" should be a miss, causing "C" to be evicted
+	shaper.Shape("A", key)
+	if shaper.Evictions != 2 {
+		t.Errorf("expected 2 evictions, got %d", shaper.Evictions)
+	}
+
+	// Re-add "B" (already in cache, so hit, moves to front)
+	shaper.Shape("B", key)
+
+	// Cache now has A and B
+	shaper.ClearCache()
+	if shaper.CacheSize() != 0 {
+		t.Errorf("expected cache size 0 after clear, got %d", shaper.CacheSize())
+	}
+	if shaper.Hits != 0 || shaper.Misses != 0 || shaper.Evictions != 0 {
+		t.Errorf("expected metrics to be reset after clear")
+	}
 }
 
 func TestShapeTextDifferentSizes(t *testing.T) {
@@ -274,6 +326,23 @@ func BenchmarkTextShaperShape(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		shaper.Shape("Hello, World!", key)
+	}
+}
+
+func BenchmarkTextShaper_Eviction(b *testing.B) {
+	shaper := NewTextShaperWithCapacity(128)
+	key := FontKey{Size: 16}
+
+	// Fill the cache
+	for i := 0; i < 128; i++ {
+		shaper.Shape("String"+string(rune(i)), key)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		// This will constantly trigger an eviction
+		shaper.Shape("Evict"+string(rune(i)), key)
 	}
 }
 


### PR DESCRIPTION
Implement bounded LRU cache for TextShaper

Problem:
The `TextShaper` in `internal/renderer/text_shaping.go` used an unbounded map to cache shaped text runs. This violated the milestone M9.2 goal to bound every cache and prevent unpredictable memory growth over long-running sessions.

Implementation summary:
- Changed the unbounded map in `TextShaper` to an LRU cache backed by a map and a doubly-linked list.
- Added a `capacity` field, defaulting to 1024, to bound memory usage.
- Added metric counters (`Hits`, `Misses`, `Evictions`).
- Re-implemented `Shape` using double-checked locking for concurrency safety and correct LRU behavior (moving items to the front on hit, evicting the tail when capacity is exceeded).
- Added tests `TestTextShaper_Eviction` and `BenchmarkTextShaper_Eviction` to prove correctness and performance of the eviction logic.
- Checked off "Text shaping cache." in `ROADMAP_V2.md`.
- Fixed a pre-existing data race in `internal/engine/session/session_test.go` where an event callback wrote to a shared variable concurrently.

Checklist:
- [x] Text shaping cache bounded
- [x] Tests cover normal, cache hit, cache miss, and eviction scenarios.
- [x] Benchmarks added for cache eviction.
- [x] Relevant paths pass `go test -race`.

Tests executed:
- `go test ./... -short`
- `go test -race ./...`

Memory and concurrency behavior:
- `TextShaper` cache is strictly bounded to an item count, preventing OOM over long lifetimes.
- `TextShaper` cache is thread-safe (`sync.Mutex` wrapping access to internal map and linked list state). 
- Resolved a data race in `session_test.go`.

Risks and known limitations:
- Bound is currently based on item count, not actual byte usage. This is acceptable for simple shaped text, but heavily varying text run lengths could still exhibit variable memory usage.

Follow-up task:
- Bound remaining caches in M9.2 (Page cache, Decoded image cache, Glyph cache, Selector and computed-style caches, etc.).

---
*PR created automatically by Jules for task [13587308493154935300](https://jules.google.com/task/13587308493154935300) started by @vyquocvu*