### PR TITLE
M9.3 Separate session state from persistent profile state

### DIFF
--- a/ROADMAP_V2.md
+++ b/ROADMAP_V2.md
@@ -719,7 +719,7 @@ Make memory and storage behavior predictable across repeated navigation and mult
 
 ### M9.3 Improve persistent storage
 
-- [ ] Separate session state from persistent profile state.
+- [x] Separate session state from persistent profile state.
 - [ ] Keep writes off the UI and engine owner goroutines.
 - [ ] Batch history and cache metadata writes.
 - [ ] Add schema versioning and migrations.

--- a/internal/profile/history.go
+++ b/internal/profile/history.go
@@ -11,15 +11,8 @@ type Visit struct {
 	VisitedAt time.Time `json:"visited_at"`
 }
 
-type SessionTab struct {
-	URL    string `json:"url"`
-	Title  string `json:"title"`
-	Active bool   `json:"active"`
-}
-
 type historyDocument struct {
-	Visits  []Visit      `json:"visits"`
-	Session []SessionTab `json:"session"`
+	Visits []Visit `json:"visits"`
 }
 
 type HistoryStore struct {
@@ -32,8 +25,7 @@ func NewHistoryStore(p *Profile) (*HistoryStore, error) {
 	store := &HistoryStore{
 		profile: p,
 		doc: historyDocument{
-			Visits:  []Visit{},
-			Session: []SessionTab{},
+			Visits: []Visit{},
 		},
 	}
 	if err := store.reloadLocked(); err != nil {
@@ -73,44 +65,19 @@ func (s *HistoryStore) VisitURLs() []string {
 	return urls
 }
 
-func (s *HistoryStore) SaveSession(tabs []SessionTab) error {
-	return s.profile.withFileLock("history.json", func() error {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-
-		if err := s.reloadLocked(); err != nil {
-			return err
-		}
-
-		s.doc.Session = append([]SessionTab(nil), tabs...)
-		return s.persist()
-	})
-}
-
-func (s *HistoryStore) SessionTabs() []SessionTab {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	return append([]SessionTab(nil), s.doc.Session...)
-}
-
 func (s *HistoryStore) reloadLocked() error {
 	if s.profile.Private() {
 		return nil
 	}
 
 	doc := historyDocument{
-		Visits:  []Visit{},
-		Session: []SessionTab{},
+		Visits: []Visit{},
 	}
 	if err := s.profile.LoadJSON("history.json", &doc); err != nil {
 		return err
 	}
 	if doc.Visits == nil {
 		doc.Visits = []Visit{}
-	}
-	if doc.Session == nil {
-		doc.Session = []SessionTab{}
 	}
 	s.doc = doc
 

--- a/internal/profile/history_test.go
+++ b/internal/profile/history_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHistoryStoreVisitsAndSessionTabs(t *testing.T) {
+func TestHistoryStoreVisits(t *testing.T) {
 	p, err := Open(Options{Root: t.TempDir()})
 	require.NoError(t, err)
 
@@ -17,14 +17,10 @@ func TestHistoryStoreVisitsAndSessionTabs(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, store.AddVisit("https://one.test", "One"))
 	require.NoError(t, store.AddVisit("https://two.test", "Two"))
-	require.NoError(t, store.SaveSession([]SessionTab{
-		{URL: "https://two.test", Title: "Two", Active: true},
-	}))
 
 	reloaded, err := NewHistoryStore(p)
 	require.NoError(t, err)
 	require.Equal(t, []string{"https://one.test", "https://two.test"}, reloaded.VisitURLs())
-	require.Equal(t, []SessionTab{{URL: "https://two.test", Title: "Two", Active: true}}, reloaded.SessionTabs())
 }
 
 func TestHistoryStoreLoadsSnakeCaseTimestampSchema(t *testing.T) {
@@ -35,13 +31,6 @@ func TestHistoryStoreLoadsSnakeCaseTimestampSchema(t *testing.T) {
       "url": "https://one.test",
       "title": "One",
       "visited_at": "2026-06-19T07:08:09Z"
-    }
-  ],
-  "session": [
-    {
-      "url": "https://one.test",
-      "title": "One",
-      "active": true
     }
   ]
 }`), 0o600)
@@ -54,30 +43,6 @@ func TestHistoryStoreLoadsSnakeCaseTimestampSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"https://one.test"}, store.VisitURLs())
 	require.Equal(t, time.Date(2026, 6, 19, 7, 8, 9, 0, time.UTC), store.doc.Visits[0].VisitedAt)
-	require.Equal(t, []SessionTab{{URL: "https://one.test", Title: "One", Active: true}}, store.SessionTabs())
-}
-
-func TestHistoryStoreSessionTabsAreCopied(t *testing.T) {
-	p, err := Open(Options{Root: t.TempDir()})
-	require.NoError(t, err)
-
-	store, err := NewHistoryStore(p)
-	require.NoError(t, err)
-
-	tabs := []SessionTab{
-		{URL: "https://one.test", Title: "One", Active: true},
-	}
-	require.NoError(t, store.SaveSession(tabs))
-	tabs[0].Title = "Changed"
-	tabs[0].Active = false
-
-	require.Equal(t, []SessionTab{{URL: "https://one.test", Title: "One", Active: true}}, store.SessionTabs())
-
-	saved := store.SessionTabs()
-	saved[0].Title = "Changed Again"
-	saved[0].Active = false
-
-	require.Equal(t, []SessionTab{{URL: "https://one.test", Title: "One", Active: true}}, store.SessionTabs())
 }
 
 func TestHistoryStoreConcurrentInstancesMergeVisits(t *testing.T) {
@@ -95,26 +60,6 @@ func TestHistoryStoreConcurrentInstancesMergeVisits(t *testing.T) {
 	reloaded, err := NewHistoryStore(p)
 	require.NoError(t, err)
 	require.Equal(t, []string{"https://one.test", "https://two.test"}, reloaded.VisitURLs())
-}
-
-func TestHistoryStoreConcurrentInstanceSaveSessionPreservesVisits(t *testing.T) {
-	p, err := Open(Options{Root: t.TempDir()})
-	require.NoError(t, err)
-
-	first, err := NewHistoryStore(p)
-	require.NoError(t, err)
-	second, err := NewHistoryStore(p)
-	require.NoError(t, err)
-
-	require.NoError(t, first.AddVisit("https://one.test", "One"))
-	require.NoError(t, second.SaveSession([]SessionTab{
-		{URL: "https://two.test", Title: "Two", Active: true},
-	}))
-
-	reloaded, err := NewHistoryStore(p)
-	require.NoError(t, err)
-	require.Equal(t, []string{"https://one.test"}, reloaded.VisitURLs())
-	require.Equal(t, []SessionTab{{URL: "https://two.test", Title: "Two", Active: true}}, reloaded.SessionTabs())
 }
 
 func TestHistoryStorePrivateDoesNotReadOrWrite(t *testing.T) {

--- a/internal/profile/session.go
+++ b/internal/profile/session.go
@@ -1,0 +1,79 @@
+package profile
+
+import (
+	"sync"
+)
+
+type SessionTab struct {
+	URL    string `json:"url"`
+	Title  string `json:"title"`
+	Active bool   `json:"active"`
+}
+
+type sessionDocument struct {
+	Session []SessionTab `json:"session"`
+}
+
+type SessionStore struct {
+	mu      sync.Mutex
+	profile *Profile
+	doc     sessionDocument
+}
+
+func NewSessionStore(p *Profile) (*SessionStore, error) {
+	store := &SessionStore{
+		profile: p,
+		doc: sessionDocument{
+			Session: []SessionTab{},
+		},
+	}
+	if err := store.reloadLocked(); err != nil {
+		return nil, err
+	}
+
+	return store, nil
+}
+
+func (s *SessionStore) SaveSession(tabs []SessionTab) error {
+	return s.profile.withFileLock("session.json", func() error {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		if err := s.reloadLocked(); err != nil {
+			return err
+		}
+
+		s.doc.Session = append([]SessionTab(nil), tabs...)
+		return s.persist()
+	})
+}
+
+func (s *SessionStore) SessionTabs() []SessionTab {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]SessionTab(nil), s.doc.Session...)
+}
+
+func (s *SessionStore) reloadLocked() error {
+	if s.profile.Private() {
+		return nil
+	}
+
+	doc := sessionDocument{
+		Session: []SessionTab{},
+	}
+	if err := s.profile.LoadJSON("session.json", &doc); err != nil {
+		return err
+	}
+	if doc.Session == nil {
+		doc.Session = []SessionTab{}
+	}
+	s.doc = doc
+
+	return nil
+}
+
+func (s *SessionStore) persist() error {
+	return s.profile.SaveJSON("session.json", s.doc)
+}

--- a/internal/profile/session_test.go
+++ b/internal/profile/session_test.go
@@ -1,0 +1,124 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionStoreSessionTabsAreSavedAndReloaded(t *testing.T) {
+	p, err := Open(Options{Root: t.TempDir()})
+	require.NoError(t, err)
+
+	store, err := NewSessionStore(p)
+	require.NoError(t, err)
+	require.NoError(t, store.SaveSession([]SessionTab{
+		{URL: "https://two.test", Title: "Two", Active: true},
+	}))
+
+	reloaded, err := NewSessionStore(p)
+	require.NoError(t, err)
+	require.Equal(t, []SessionTab{{URL: "https://two.test", Title: "Two", Active: true}}, reloaded.SessionTabs())
+}
+
+func TestSessionStoreLoadsJSONSchema(t *testing.T) {
+	root := t.TempDir()
+	err := os.WriteFile(filepath.Join(root, "session.json"), []byte(`{
+  "session": [
+    {
+      "url": "https://one.test",
+      "title": "One",
+      "active": true
+    }
+  ]
+}`), 0o600)
+	require.NoError(t, err)
+
+	p, err := Open(Options{Root: root})
+	require.NoError(t, err)
+
+	store, err := NewSessionStore(p)
+	require.NoError(t, err)
+	require.Equal(t, []SessionTab{{URL: "https://one.test", Title: "One", Active: true}}, store.SessionTabs())
+}
+
+func TestSessionStoreSessionTabsAreCopied(t *testing.T) {
+	p, err := Open(Options{Root: t.TempDir()})
+	require.NoError(t, err)
+
+	store, err := NewSessionStore(p)
+	require.NoError(t, err)
+
+	tabs := []SessionTab{
+		{URL: "https://one.test", Title: "One", Active: true},
+	}
+	require.NoError(t, store.SaveSession(tabs))
+	tabs[0].Title = "Changed"
+	tabs[0].Active = false
+
+	require.Equal(t, []SessionTab{{URL: "https://one.test", Title: "One", Active: true}}, store.SessionTabs())
+
+	saved := store.SessionTabs()
+	saved[0].Title = "Changed Again"
+	saved[0].Active = false
+
+	require.Equal(t, []SessionTab{{URL: "https://one.test", Title: "One", Active: true}}, store.SessionTabs())
+}
+
+func TestSessionStoreConcurrentInstanceSaveSessionWorks(t *testing.T) {
+	p, err := Open(Options{Root: t.TempDir()})
+	require.NoError(t, err)
+
+	first, err := NewSessionStore(p)
+	require.NoError(t, err)
+	second, err := NewSessionStore(p)
+	require.NoError(t, err)
+
+	require.NoError(t, first.SaveSession([]SessionTab{
+		{URL: "https://one.test", Title: "One", Active: true},
+	}))
+	require.NoError(t, second.SaveSession([]SessionTab{
+		{URL: "https://two.test", Title: "Two", Active: true},
+	}))
+
+	reloaded, err := NewSessionStore(p)
+	require.NoError(t, err)
+	// Last write wins for session
+	require.Equal(t, []SessionTab{{URL: "https://two.test", Title: "Two", Active: true}}, reloaded.SessionTabs())
+}
+
+func TestSessionStorePrivateDoesNotReadOrWrite(t *testing.T) {
+	root := t.TempDir()
+
+	// Write session as a normal profile.
+	normal, err := Open(Options{Root: root})
+	require.NoError(t, err)
+	normalStore, err := NewSessionStore(normal)
+	require.NoError(t, err)
+	require.NoError(t, normalStore.SaveSession([]SessionTab{
+		{URL: "https://persisted.example.com", Title: "Persisted", Active: true},
+	}))
+
+	// Open a private profile in the same root — should not read persisted data.
+	priv, err := Open(Options{Root: root, Private: true})
+	require.NoError(t, err)
+	privStore, err := NewSessionStore(priv)
+	require.NoError(t, err)
+	require.Empty(t, privStore.SessionTabs(),
+		"private profile must not read session from disk")
+
+	// Mutate and verify nothing is written to disk.
+	require.NoError(t, privStore.SaveSession([]SessionTab{
+		{URL: "https://private.example.com", Title: "Private", Active: true},
+	}))
+
+	// Re-open as normal — should still have only the original session.
+	normal2, err := Open(Options{Root: root})
+	require.NoError(t, err)
+	normal2Store, err := NewSessionStore(normal2)
+	require.NoError(t, err)
+	require.Equal(t, []SessionTab{{URL: "https://persisted.example.com", Title: "Persisted", Active: true}}, normal2Store.SessionTabs(),
+		"private writes must not persist to disk")
+}

--- a/internal/renderer/frame/cache/cache_test.go
+++ b/internal/renderer/frame/cache/cache_test.go
@@ -240,7 +240,7 @@ func TestGlyphCacheByteLimitOversizedItem(t *testing.T) {
 }
 
 func TestGlyphCacheByteLimitLRUOrder(t *testing.T) {
-	c := NewGlyphCacheWithBytes(100, 300) // 300 byte limit
+	c := NewGlyphCacheWithBytes(100, 300)                  // 300 byte limit
 	c.Put(GlyphKey{GlyphID: 0}, GlyphValue{ByteSize: 100}) // oldest
 	c.Put(GlyphKey{GlyphID: 1}, GlyphValue{ByteSize: 100})
 	c.Put(GlyphKey{GlyphID: 2}, GlyphValue{ByteSize: 100})


### PR DESCRIPTION
This PR implements the "Separate session state from persistent profile state" task under M9.3. `SessionTab`s have been moved out of `HistoryStore` (`history.json`) and into a dedicated `SessionStore` (`session.json`) to keep active state logically and physically distinct from long-term profile data (visits). Tests and the ROADMAP have been updated.

---
*PR created automatically by Jules for task [6235975986673762575](https://jules.google.com/task/6235975986673762575) started by @vyquocvu*