### PR TITLE
Fix GC thrashing detection flake

### DIFF
--- a/internal/memory/tuning.go
+++ b/internal/memory/tuning.go
@@ -98,12 +98,17 @@ func EvaluateConfig(cfg TuningConfig, workload func()) WorkloadStats {
 		totalPause = endGCStats.PauseTotal - startGCStats.PauseTotal
 	}
 
-	// Thrashing detection:
-	// 1. GC CPU fraction exceeds 20%
-	// 2. High frequency of GC cycles relative to time (e.g. >100 GCs/sec)
+	// Thrashing detection uses metrics from this workload only. MemStats.GCCPUFraction
+	// is process-wide since program start, so using it directly can make otherwise
+	// healthy short workloads fail when prior tests or CI startup performed GC work.
+	// Instead, mark thrashing when this run spent a large share of its own wall
+	// time paused for GC, or when it sustained a very high GC rate.
 	thrashing := false
-	if gccpu > 0.20 {
-		thrashing = true
+	if duration > 0 && totalPause > 0 {
+		pauseFraction := float64(totalPause) / float64(duration)
+		if pauseFraction > 0.20 {
+			thrashing = true
+		}
 	}
 	if duration > 10*time.Millisecond {
 		gcRate := float64(numGC) / duration.Seconds()

--- a/internal/memory/tuning.go
+++ b/internal/memory/tuning.go
@@ -88,15 +88,10 @@ func EvaluateConfig(cfg TuningConfig, workload func()) WorkloadStats {
 	allocatedBytes := endMem.TotalAlloc - startMem.TotalAlloc
 	gccpu := endMem.GCCPUFraction
 
-	var totalPause time.Duration
-	if len(endGCStats.Pause) > len(startGCStats.Pause) {
-		diff := len(endGCStats.Pause) - len(startGCStats.Pause)
-		for i := 0; i < diff && i < len(endGCStats.Pause); i++ {
-			totalPause += endGCStats.Pause[i]
-		}
-	} else if len(endGCStats.Pause) > 0 {
-		totalPause = endGCStats.PauseTotal - startGCStats.PauseTotal
-	}
+	// PauseTotal is cumulative, so subtract snapshots to measure only GC pause
+	// time attributable to this workload. Avoid summing the Pause ring because it
+	// can already contain historical entries before the workload starts.
+	totalPause := endGCStats.PauseTotal - startGCStats.PauseTotal
 
 	// Thrashing detection uses metrics from this workload only. MemStats.GCCPUFraction
 	// is process-wide since program start, so using it directly can make otherwise


### PR DESCRIPTION
### Motivation
- The previous thrashing detection relied on `MemStats.GCCPUFraction`, which is process-wide and can be polluted by prior tests or CI startup GC activity, causing flaky failures for short workloads.
- The goal is to detect genuine GC thrashing caused by the current workload while avoiding false positives from earlier runtime activity.

### Description
- Replace the `GCCPUFraction`-based threshold with a workload-local `pauseFraction` computed from GC pause time deltas in `internal/memory/tuning.go`.
- Preserve the sustained high-GC-rate check (`gcRate > 100 GCs/sec`) to detect genuine, rapid GC churn.
- Update comments to explain why process-wide `GCCPUFraction` is avoided and how pause-based detection is used.

### Testing
- Ran `go test ./internal/memory` which completed successfully and the memory tests passed. 
- Running `go test ./...` in the local environment failed to complete due to missing system OpenGL/X11 development dependencies (`gl.pc` and `X11/Xcursor/Xcursor.h`), which are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57523154c88326a0b353a894c74689)