### PR TITLE
Implement DevTools Console Command History

### DIFF
--- a/internal/ui/console.go
+++ b/internal/ui/console.go
@@ -9,6 +9,62 @@ import (
 	"github.com/vyquocvu/goosie/internal/js"
 )
 
+// ConsoleEntry is a custom entry widget that supports command history via up/down arrows.
+type ConsoleEntry struct {
+	widget.Entry
+	history      []string
+	historyIndex int
+}
+
+// NewConsoleEntry creates a new ConsoleEntry.
+func NewConsoleEntry() *ConsoleEntry {
+	e := &ConsoleEntry{
+		history:      make([]string, 0),
+		historyIndex: -1,
+	}
+	e.ExtendBaseWidget(e)
+	return e
+}
+
+// TypedKey handles key events to provide command history navigation.
+func (e *ConsoleEntry) TypedKey(k *fyne.KeyEvent) {
+	if k.Name == fyne.KeyUp {
+		if len(e.history) > 0 {
+			if e.historyIndex < 0 {
+				e.historyIndex = len(e.history) - 1
+			} else if e.historyIndex > 0 {
+				e.historyIndex--
+			}
+			e.SetText(e.history[e.historyIndex])
+		}
+	} else if k.Name == fyne.KeyDown {
+		if len(e.history) > 0 && e.historyIndex >= 0 {
+			if e.historyIndex < len(e.history)-1 {
+				e.historyIndex++
+				e.SetText(e.history[e.historyIndex])
+			} else {
+				e.historyIndex = -1
+				e.SetText("")
+			}
+		}
+	} else {
+		e.Entry.TypedKey(k)
+	}
+}
+
+// AddHistory adds a command to the history if it is not empty.
+func (e *ConsoleEntry) AddHistory(cmd string) {
+	if cmd == "" {
+		return
+	}
+	if len(e.history) > 0 && e.history[len(e.history)-1] == cmd {
+		e.historyIndex = -1
+		return
+	}
+	e.history = append(e.history, cmd)
+	e.historyIndex = -1
+}
+
 // ConsolePanel represents the developer console panel
 type ConsolePanel struct {
 	container       *fyne.Container
@@ -18,7 +74,7 @@ type ConsolePanel struct {
 	closeButton     *widget.Button
 	filterSelect    *widget.Select
 	filterLevel     string
-	commandEntry    *widget.Entry
+	commandEntry    *ConsoleEntry
 	onExecute       func(string)
 	onRefresh       func()
 	onClose         func()
@@ -130,10 +186,11 @@ func NewConsolePanel(onClose func()) *ConsolePanel {
 		container.NewHBox(panel.clearButton, panel.closeButton),
 		container.NewHBox(widget.NewLabel("Filter:"), panel.filterSelect, panel.errorCountLabel),
 	)
-	panel.commandEntry = widget.NewEntry()
+	panel.commandEntry = NewConsoleEntry()
 	panel.commandEntry.SetPlaceHolder("Execute JavaScript")
 	panel.commandEntry.OnSubmitted = func(source string) {
 		if panel.onExecute != nil && source != "" {
+			panel.commandEntry.AddHistory(source)
 			panel.onExecute(source)
 			panel.commandEntry.SetText("")
 		}

--- a/internal/ui/console.go
+++ b/internal/ui/console.go
@@ -22,6 +22,7 @@ func NewConsoleEntry() *ConsoleEntry {
 		history:      make([]string, 0),
 		historyIndex: -1,
 	}
+	e.Wrapping = fyne.TextTruncate
 	e.ExtendBaseWidget(e)
 	return e
 }

--- a/internal/ui/console_test.go
+++ b/internal/ui/console_test.go
@@ -1,0 +1,83 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/vyquocvu/goosie/internal/js"
+)
+
+func TestConsolePanel_LogFiltering(t *testing.T) {
+	test.NewApp()
+	panel := NewConsolePanel(nil)
+
+	panel.AddMessage(js.ConsoleMessage{Level: "error", Data: "test error", Timestamp: time.Now()})
+	panel.AddMessage(js.ConsoleMessage{Level: "log", Data: "test log", Timestamp: time.Now()})
+
+	assert.Equal(t, 2, panel.getFilteredMessageCount())
+
+	panel.filterSelect.SetSelected("error")
+
+	assert.Equal(t, 1, panel.getFilteredMessageCount())
+	assert.Equal(t, "test error", panel.getFilteredMessage(0).Data)
+}
+
+func TestConsolePanel_Execute(t *testing.T) {
+    test.NewApp()
+    panel := NewConsolePanel(nil)
+
+    executedCmd := ""
+    panel.SetExecuteCallback(func(cmd string) {
+        executedCmd = cmd
+    })
+
+    panel.commandEntry.SetText("test cmd")
+    panel.commandEntry.OnSubmitted("test cmd")
+
+    assert.Equal(t, "test cmd", executedCmd)
+    assert.Equal(t, "", panel.commandEntry.Text)
+}
+
+func TestConsoleEntry_History(t *testing.T) {
+	test.NewApp()
+	entry := NewConsoleEntry()
+
+	entry.AddHistory("cmd 1")
+	entry.AddHistory("cmd 2")
+
+	// up
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyUp})
+	assert.Equal(t, "cmd 2", entry.Text)
+
+	// up
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyUp})
+	assert.Equal(t, "cmd 1", entry.Text)
+
+	// up again (should stay at oldest)
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyUp})
+	assert.Equal(t, "cmd 1", entry.Text)
+
+	// down
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyDown})
+	assert.Equal(t, "cmd 2", entry.Text)
+
+	// down (should clear)
+	entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyDown})
+	assert.Equal(t, "", entry.Text)
+}
+
+func TestConsoleEntry_DuplicateHistory(t *testing.T) {
+	test.NewApp()
+	entry := NewConsoleEntry()
+
+	entry.AddHistory("cmd 1")
+	entry.AddHistory("cmd 1")
+	entry.AddHistory("cmd 2")
+
+	assert.Equal(t, 2, len(entry.history))
+	assert.Equal(t, "cmd 1", entry.history[0])
+	assert.Equal(t, "cmd 2", entry.history[1])
+}

--- a/internal/ui/inspect_panel_test.go
+++ b/internal/ui/inspect_panel_test.go
@@ -533,3 +533,15 @@ func TestElementsPanel_MatchedCSSRules(t *testing.T) {
 	assert.NotEmpty(t, panel.stylesContainer.Objects)
 }
 
+
+func TestElementsPanel_PopulateAndExpand(t *testing.T) {
+	test.NewApp()
+	mockRoot := &renderer.RenderNode{ID: 1, TagName: "html", Type: renderer.NodeTypeElement}
+	mockRoot.Children = append(mockRoot.Children, &renderer.RenderNode{ID: 2, TagName: "body", Type: renderer.NodeTypeElement})
+
+	panel := NewInspectPanel(nil)
+	panel.SetRenderer(&MockHTMLRenderer{root: mockRoot})
+
+	assert.True(t, panel.tree.IsBranchOpen("1"))
+	assert.True(t, panel.tree.IsBranchOpen("2"))
+}


### PR DESCRIPTION
Implemented command history traversal in the Developer Console using Up/Down arrow keys, fulfilling the console functionality specification in `ROADMAP_DEVTOOLS.md`.

---
*PR created automatically by Jules for task [11936464620382926820](https://jules.google.com/task/11936464620382926820) started by @vyquocvu*