### PR TITLE
Add headless build-tag switch and size-optimized build targets (Makefile, headless app)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,22 @@ COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
 BUILDTIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # Build flags
-LDFLAGS=-ldflags "-s -w -X github.com/vyquocvu/goosie/internal/version.Version=$(VERSION) -X github.com/vyquocvu/goosie/internal/version.Commit=$(COMMIT) -X github.com/vyquocvu/goosie/internal/version.BuildTime=$(BUILDTIME)"
+VERSION_LDFLAGS=-X github.com/vyquocvu/goosie/internal/version.Version=$(VERSION) -X github.com/vyquocvu/goosie/internal/version.Commit=$(COMMIT) -X github.com/vyquocvu/goosie/internal/version.BuildTime=$(BUILDTIME)
+LDFLAGS=-ldflags "-s -w $(VERSION_LDFLAGS)"
 
 # Reproducible build flags for release builds
 REPRODUCIBLE_FLAGS=-trimpath -ldflags "-s -w -buildid= -X github.com/vyquocvu/goosie/internal/version.Version=$(VERSION) -X github.com/vyquocvu/goosie/internal/version.Commit=$(COMMIT) -X github.com/vyquocvu/goosie/internal/version.BuildTime=reproducible"
 
-# Headless build variant (no Fyne dependency)
-HEADLESS_FLAGS=-tags headless -trimpath -ldflags "-s -w -X github.com/vyquocvu/goosie/internal/version.Version=$(VERSION) -X github.com/vyquocvu/goosie/internal/version.Commit=$(COMMIT) -X github.com/vyquocvu/goosie/internal/version.BuildTime=$(BUILDTIME)"
+# Size-optimized release flags. UPX compression is optional because it can slow
+# startup slightly and may be rejected by some antivirus scanners.
+SMALL_FLAGS=-trimpath -ldflags "-s -w -buildid= $(VERSION_LDFLAGS)"
+UPX ?= upx
+UPX_FLAGS ?= --best --lzma
 
-.PHONY: all build build-reproducible build-headless clean install-playwright test generate-test-data smoke-test
+# Headless browser variant for URL screenshots via Fyne test driver
+HEADLESS_FLAGS=-tags headless -trimpath -ldflags "-s -w $(VERSION_LDFLAGS)"
+
+.PHONY: all build build-small build-small-upx build-reproducible build-headless clean install-playwright test generate-test-data smoke-test
 
 all: build
 
@@ -27,6 +34,17 @@ build:
 	@mkdir -p $(BUILD_DIR)
 	go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/browser
 	@echo "Build complete: $(BUILD_DIR)/$(BINARY_NAME)"
+
+build-small:
+	@echo "Building $(BINARY_NAME) (size optimized)..."
+	@mkdir -p $(BUILD_DIR)
+	go build $(SMALL_FLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-small ./cmd/browser
+	@echo "Size-optimized build complete: $(BUILD_DIR)/$(BINARY_NAME)-small"
+
+build-small-upx: build-small
+	@command -v $(UPX) >/dev/null 2>&1 || (echo "UPX not found; install upx or set UPX=/path/to/upx"; exit 1)
+	$(UPX) $(UPX_FLAGS) $(BUILD_DIR)/$(BINARY_NAME)-small
+	@echo "UPX-compressed build complete: $(BUILD_DIR)/$(BINARY_NAME)-small"
 
 build-reproducible:
 	@echo "Building $(BINARY_NAME) (reproducible)..."

--- a/README.md
+++ b/README.md
@@ -47,15 +47,38 @@ make build
 ./bin/goosie
 ```
 
-## Headless rendering
-
-Capture a website:
+For a smaller release binary, use the size-optimized target. It keeps the
+existing symbol/debug stripping, removes local path metadata with `-trimpath`,
+and clears the Go build ID for reproducible, slightly smaller output:
 
 ```bash
-go run ./cmd/browser -headless \
+make build-small
+./bin/goosie-small
+```
+
+If you need the smallest distributable file and accept the trade-offs of packed
+executables (slightly slower startup and occasional antivirus false positives),
+install UPX and run:
+
+```bash
+make build-small-upx
+```
+
+## Headless rendering
+
+Capture a website with the headless-tag browser build:
+
+```bash
+go run -tags headless ./cmd/browser -headless \
   -url=https://example.com \
   -screenshot=screenshot.png
+# or build it first
+make build-headless
+./bin/goosie-headless -headless -url=https://example.com -screenshot=screenshot.png
 ```
+
+The default GUI build intentionally leaves out Fyne's test driver to keep the
+binary smaller; use the headless-tag build above for URL screenshots.
 
 Render local HTML or standard input directly to PNG:
 

--- a/cmd/browser/headless_app.go
+++ b/cmd/browser/headless_app.go
@@ -1,0 +1,15 @@
+//go:build headless
+
+package main
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+)
+
+func newHeadlessAppWindow() (fyne.App, fyne.Window, error) {
+	a := test.NewApp()
+	w := a.NewWindow("Goosie Headless")
+	w.Resize(fyne.NewSize(1000, 700))
+	return a, w, nil
+}

--- a/cmd/browser/headless_app_disabled.go
+++ b/cmd/browser/headless_app_disabled.go
@@ -1,0 +1,13 @@
+//go:build !headless
+
+package main
+
+import (
+	"fmt"
+
+	"fyne.io/fyne/v2"
+)
+
+func newHeadlessAppWindow() (fyne.App, fyne.Window, error) {
+	return nil, nil, fmt.Errorf("the -headless browser mode requires a headless-tag build; use `make build-headless` for URL screenshots or `make build-headless-cli` for stdin/local HTML rendering")
+}

--- a/cmd/browser/main.go
+++ b/cmd/browser/main.go
@@ -14,7 +14,6 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/dialog"
-	"fyne.io/fyne/v2/test"
 	"github.com/vyquocvu/goosie/internal/dom"
 	"github.com/vyquocvu/goosie/internal/engine/navigation"
 	"github.com/vyquocvu/goosie/internal/engine/session"
@@ -81,9 +80,10 @@ func main() {
 	var a fyne.App
 	var w fyne.Window
 	if *headlessFlag {
-		a = test.NewApp()
-		w = a.NewWindow("Goosie Headless")
-		w.Resize(fyne.NewSize(1000, 700))
+		a, w, err = newHeadlessAppWindow()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	memMgr := memory.NewManager(memory.Config{
@@ -704,4 +704,3 @@ func getFilenameFromURLAndCD(urlStr, cd string) string {
 
 	return "download.bin"
 }
-


### PR DESCRIPTION
### Motivation

- Provide an explicit build-tag pathway for headless/Fyne test-driver usage so headless UI code is only included in builds that opt in.
- Offer smaller, reproducible and optionally UPX-compressed release binaries to reduce distribution size.
- Improve build flag reuse and clarity for LDFLAGS and version injection.

### Description

- Introduce `newHeadlessAppWindow` with two build-tag variants: `cmd/browser/headless_app.go` (for `//go:build headless`) to create a `test.NewApp()` window and `cmd/browser/headless_app_disabled.go` (for `//go:build !headless`) which returns an explanatory error. 
- Update `cmd/browser/main.go` to call `newHeadlessAppWindow()` when `-headless` is requested and remove the direct dependency on `fyne.io/fyne/v2/test` from `main.go`.
- Revise `Makefile` to factor `VERSION_LDFLAGS`, add `SMALL_FLAGS`, `build-small` and `build-small-upx` targets, expose optional `UPX` and `UPX_FLAGS`, and add `build-small`/`build-small-upx` to `.PHONY`; keep `build-reproducible` and `build-headless` targets. 
- Update `README.md` to document `make build-small`, `make build-small-upx`, and to clarify headless usage with the `-tags headless` build.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57db03921883268b097bb0c6eb5b19)